### PR TITLE
Add Customer Service section to landing page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,8 @@
-- [x] Fix product useMemo fallback to return products[0] instead of products
-- [x] Fix variantId state initialization to use product.variants[0]?.id
-- [x] Fix variant useMemo fallback to use product.variants[0]
+# TODO: Add Customer Service Section to Landing Page
+
+- [x] Create /terms page with Terms and Conditions content
+- [x] Create /privacy page with Privacy Policy content
+- [x] Create /return-replacement page with Return and Replacement Policy content
+- [x] Create /contact page with Contact Us content
+- [x] Create /track-order page with Track Order content
+- [x] Add Customer Service section to landing page (src/app/page.tsx) with links to the above pages

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,20 @@
+export default function ContactPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Contact Us</h1>
+      <div className="prose">
+        <p>We'd love to hear from you! If you have any questions, feedback, or need assistance, please reach out to us using the information below.</p>
+        <h2>Contact Information</h2>
+        <p><strong>Email:</strong> support@econutrient.com</p>
+        <p><strong>Phone:</strong> +1 (555) 123-4567</p>
+        <p><strong>Address:</strong> 123 Eco Street, Green City, GC 12345</p>
+        <h2>Business Hours</h2>
+        <p>Monday - Friday: 9:00 AM - 6:00 PM EST</p>
+        <p>Saturday: 10:00 AM - 4:00 PM EST</p>
+        <p>Sunday: Closed</p>
+        <h2>Send us a Message</h2>
+        <p>For inquiries, please email us or call during business hours. We aim to respond within 24 hours.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,17 @@ export default function HomePage() {
       <section id="shop" className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <ProductCard product={sattu} />
       </section>
+
+      <section className="text-center">
+        <h2 className="text-2xl font-bold mb-6">Customer Service</h2>
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
+          <Link href="/terms" className="text-eco-green hover:underline">Terms and Conditions</Link>
+          <Link href="/privacy" className="text-eco-green hover:underline">Privacy Policy</Link>
+          <Link href="/return-replacement" className="text-eco-green hover:underline">Return and Replacement Policy</Link>
+          <Link href="/contact" className="text-eco-green hover:underline">Contact Us</Link>
+          <Link href="/track-order" className="text-eco-green hover:underline">Track Order</Link>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,20 @@
+export default function PrivacyPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
+      <div className="prose">
+        <p>At EcoNutrient, we are committed to protecting your privacy. This privacy policy explains how we collect, use, and safeguard your information.</p>
+        <h2>1. Information We Collect</h2>
+        <p>We may collect personal information such as your name, email address, shipping address, and payment information when you make a purchase or contact us.</p>
+        <h2>2. How We Use Your Information</h2>
+        <p>Your information is used to process orders, provide customer service, and improve our products and services. We do not sell or share your personal information with third parties.</p>
+        <h2>3. Data Security</h2>
+        <p>We implement appropriate security measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction.</p>
+        <h2>4. Cookies</h2>
+        <p>Our website may use cookies to enhance your browsing experience. You can control cookie settings through your browser.</p>
+        <h2>5. Contact Us</h2>
+        <p>If you have any questions about this privacy policy, please contact us at privacy@econutrient.com.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/return-replacement/page.tsx
+++ b/src/app/return-replacement/page.tsx
@@ -1,0 +1,18 @@
+export default function ReturnReplacementPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Return and Replacement Policy</h1>
+      <div className="prose">
+        <p>At EcoNutrient, we want you to be completely satisfied with your purchase. If you are not satisfied, please review our return and replacement policy below.</p>
+        <h2>1. Returns</h2>
+        <p>Products can be returned within 30 days of receipt, provided they are unused and in their original packaging. Please contact our customer service to initiate a return.</p>
+        <h2>2. Replacements</h2>
+        <p>If you receive a damaged or defective product, we will replace it free of charge. Please contact us within 7 days of receiving the product with details and photos.</p>
+        <h2>3. Refunds</h2>
+        <p>Refunds will be processed after we receive and inspect the returned product. Refunds will be issued to the original payment method.</p>
+        <h2>4. Contact Information</h2>
+        <p>For any questions regarding returns or replacements, please contact us at support@econutrient.com.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,20 @@
+export default function TermsPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Terms and Conditions</h1>
+      <div className="prose">
+        <p>Welcome to EcoNutrient. By accessing and using our website, you agree to comply with and be bound by the following terms and conditions.</p>
+        <h2>1. Acceptance of Terms</h2>
+        <p>By using this website, you accept these terms and conditions in full. If you disagree with these terms, you must not use this website.</p>
+        <h2>2. Use of Website</h2>
+        <p>You may use our website for lawful purposes only. You must not use our site in any way that causes, or may cause, damage to the website or impairment of the availability or accessibility of the website.</p>
+        <h2>3. Products and Services</h2>
+        <p>All products are subject to availability. We reserve the right to discontinue any product at any time. Prices are subject to change without notice.</p>
+        <h2>4. Limitation of Liability</h2>
+        <p>EcoNutrient will not be liable for any direct, indirect, incidental, or consequential damages arising from the use of our products or website.</p>
+        <h2>5. Governing Law</h2>
+        <p>These terms and conditions are governed by and construed in accordance with the laws of [Your Jurisdiction].</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/track-order/page.tsx
+++ b/src/app/track-order/page.tsx
@@ -1,0 +1,24 @@
+export default function TrackOrderPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Track Your Order</h1>
+      <div className="prose">
+        <p>Track the status of your EcoNutrient order easily. Enter your order number and email address below to get real-time updates.</p>
+        <h2>How to Track Your Order</h2>
+        <ol>
+          <li>Locate your order confirmation email, which contains your order number.</li>
+          <li>Enter your order number and the email address used for the order in the form below.</li>
+          <li>Click "Track Order" to view the current status.</li>
+        </ol>
+        <h2>Order Status Meanings</h2>
+        <ul>
+          <li><strong>Processing:</strong> Your order is being prepared for shipment.</li>
+          <li><strong>Shipped:</strong> Your order has been dispatched and is on its way.</li>
+          <li><strong>Delivered:</strong> Your order has been successfully delivered.</li>
+        </ul>
+        <h2>Need Help?</h2>
+        <p>If you encounter any issues tracking your order or have questions, please contact our customer service at support@econutrient.com.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Added Customer Service section at the bottom of the homepage with links to newly created pages for Terms and Conditions, Privacy Policy, Return and Replacement Policy, Contact Us, and Track Order. Each page includes relevant placeholder content.