### PR TITLE
Fix TypeScript compilation error for 'aos' module

### DIFF
--- a/src/types/aos.d.ts
+++ b/src/types/aos.d.ts
@@ -1,0 +1,1 @@
+declare module 'aos';


### PR DESCRIPTION
This PR fixes the build failure by adding type declarations for the 'aos' module.